### PR TITLE
Update Server struct

### DIFF
--- a/wiki.go
+++ b/wiki.go
@@ -18,8 +18,8 @@ import (
 // Server is whole server implementation for this wiki app.
 // This holds database connection and router settings.
 type Server struct {
-	db  *sql.DB
-	mux *http.ServeMux
+	db      *sql.DB
+	handler http.Handler
 }
 
 // Close makes the database connection to close.
@@ -65,7 +65,7 @@ func (s *Server) Run(addr string) {
 	// NOTE: when you serve on TLS, make csrf.Secure(true)
 	CSRF := csrf.Protect(
 		csrfProtectKey, csrf.Secure(false))
-	http.ListenAndServe(addr, context.ClearHandler(CSRF(s.mux)))
+	http.ListenAndServe(addr, context.ClearHandler(CSRF(s.handler)))
 }
 
 // Route setting router for this wiki.
@@ -87,5 +87,5 @@ func (s *Server) Route() {
 	mux.Handle("/signup", handler(user.SignupHandler))
 	mux.Handle("/login", handler(user.LoginHandler))
 	mux.Handle("/static", http.FileServer(http.Dir("./static")))
-	s.mux = mux
+	s.handler = mux
 }

--- a/wiki.go
+++ b/wiki.go
@@ -16,7 +16,7 @@ import (
 )
 
 // Server is whole server implementation for this wiki app.
-// This holds database connection and router settings based on gin.
+// This holds database connection and router settings.
 type Server struct {
 	db  *sql.DB
 	mux *http.ServeMux


### PR DESCRIPTION
I updated godoc of `Server` struct because I think we no longer use `gin` in this project.
Moreover, I replaced mux(*http.ServerMux) to handler(http.Handler) for flexibility reasons.

もうこのプロジェクトでは`gin`を使ってないので、構造体`Server`のgodocから「`Server`のルーターの設定は`gin`をベースにした」という旨の文を削除しました。
また、構造体`Server`のルーターはインターフェース`http.Handler`相当の機能を持っていれば十分なので、柔軟性のために`mux`（`*http.ServerMux`型）を`handler`（`http.Handler`型）に置き換えました。